### PR TITLE
feat: add homebrew formula

### DIFF
--- a/Formula/git-wt.rb
+++ b/Formula/git-wt.rb
@@ -1,0 +1,28 @@
+# typed: false
+# frozen_string_literal: true
+
+class GitWt < Formula
+  desc 'Interactive TUI for git worktree management'
+  homepage 'https://github.com/nsheaps/git-wt'
+  url 'https://github.com/nsheaps/git-wt/archive/refs/tags/v0.4.4.tar.gz'
+  sha256 'b3f4d98dd2c7281d45b8d59f36b97254675327a08b4db35ac327f70cf14624b8'
+  license 'MIT'
+
+  head do
+    url 'https://github.com/nsheaps/git-wt.git', branch: 'main'
+  end
+
+  depends_on 'gum'
+
+  def install
+    if build.head?
+      bin.install 'bin/git-wt'
+    else
+      bin.install 'git-wt'
+    end
+  end
+
+  test do
+    assert_match 'git-wt', shell_output("#{bin}/git-wt --help")
+  end
+end


### PR DESCRIPTION
## Summary
- Adds homebrew formula to the repository
- Does not include explicit `version` field - homebrew infers version from URL tag
- Matches formatting from homebrew-devsetup

## Context
The formula was previously only in `nsheaps/homebrew-devsetup`. Adding it here keeps it closer to the source and makes it easier to maintain during releases.

## Test plan
- [ ] Verify formula installs correctly: `brew install --build-from-source ./Formula/git-wt.rb`
- [ ] Verify `git-wt --help` works after installation

---
Generated with [Claude Code](https://claude.com/claude-code)