### PR TITLE
fix: use correct install path in homebrew formula template

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -141,11 +141,7 @@ jobs:
             depends_on 'gum'
 
             def install
-              if build.head?
-                bin.install 'bin/git-wt'
-              else
-                bin.install 'git-wt'
-              end
+              bin.install 'bin/git-wt'
             end
 
             test do


### PR DESCRIPTION
## Summary
- Fix homebrew formula template to use `bin/git-wt` install path
- Archive tarballs have the script at `bin/git-wt`, not at root
- Fixes "No such file or directory - git-wt" error during `brew install`

## Test plan
- [ ] Next release should generate correct formula
- [ ] `brew install nsheaps/devsetup/git-wt` should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)