### PR TITLE
fix: embed version in tagged commit, reset main to placeholder

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,12 +52,18 @@ jobs:
             echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Embed version in script
+        if: steps.next-version.outputs.will-release == 'true'
+        run: |
+          # Embed version before release-it commits, so the tagged commit has it
+          sed -i -E 's/GIT_WT_VERSION="(__VERSION__|v[0-9]+\.[0-9]+\.[0-9]+)"/GIT_WT_VERSION="${{ steps.next-version.outputs.tag }}"/' bin/git-wt
+
       - name: Run release-it
         id: release
         if: steps.next-version.outputs.will-release == 'true'
         run: |
           # Run release-it to bump version, update changelog, commit, and tag
-          # Source keeps __VERSION__ placeholder - version embedded only in release asset
+          # The embedded version will be included in the tagged commit
           if yarn release-it --ci; then
             echo "released=true" >> "$GITHUB_OUTPUT"
             echo "version=${{ steps.next-version.outputs.version }}" >> "$GITHUB_OUTPUT"
@@ -70,13 +76,20 @@ jobs:
       - name: Create GitHub release
         if: steps.release.outputs.released == 'true'
         run: |
-          # Create versioned copy for release asset (source keeps __VERSION__)
-          cp bin/git-wt /tmp/git-wt
-          sed -i 's/__VERSION__/${{ steps.release.outputs.tag }}/' /tmp/git-wt
+          # Upload bin/git-wt which still has the embedded version
           gh release create "${{ steps.release.outputs.tag }}" \
-            /tmp/git-wt#git-wt \
+            bin/git-wt \
             --title "${{ steps.release.outputs.tag }}" \
             --generate-notes
+
+      - name: Reset version to placeholder
+        if: steps.release.outputs.released == 'true'
+        run: |
+          # Reset to __VERSION__ so main branch stays clean
+          sed -i -E 's/GIT_WT_VERSION="v[0-9]+\.[0-9]+\.[0-9]+"/GIT_WT_VERSION="__VERSION__"/' bin/git-wt
+          git add bin/git-wt
+          git commit -m "chore: reset version placeholder [skip ci]"
+          git push
 
   update-homebrew:
     if: needs.release.outputs.released == 'true'
@@ -106,22 +119,14 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
-          # Download release asset and calculate SHA256
-          ASSET_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/git-wt"
-          echo "Downloading release asset from: $ASSET_URL"
-          # Retry a few times in case of CDN propagation delay
-          for i in {1..5}; do
-            if curl -fsSL "$ASSET_URL" -o /tmp/git-wt; then
-              SHA256=$(shasum -a 256 /tmp/git-wt | cut -d' ' -f1)
-              echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
-              echo "Successfully got SHA256: $SHA256"
-              exit 0
-            fi
-            echo "Attempt $i failed, retrying in 5s..."
-            sleep 5
-          done
-          echo "Failed to download release asset"
-          exit 1
+          # Download archive tarball and calculate SHA256
+          # Archive is available instantly (no CDN delay like release assets)
+          TARBALL_URL="https://github.com/${{ github.repository }}/archive/refs/tags/${TAG}.tar.gz"
+          echo "Downloading tarball from: $TARBALL_URL"
+          curl -fsSL "$TARBALL_URL" -o /tmp/archive.tar.gz
+          SHA256=$(shasum -a 256 /tmp/archive.tar.gz | cut -d' ' -f1)
+          echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
+          echo "Successfully got SHA256: $SHA256"
 
       - name: Clone homebrew-devsetup
         run: |
@@ -137,7 +142,7 @@ jobs:
           class GitWt < Formula
             desc 'Interactive TUI for git worktree management'
             homepage 'https://github.com/nsheaps/git-wt'
-            url 'https://github.com/nsheaps/git-wt/releases/download/${{ steps.release.outputs.tag }}/git-wt'
+            url 'https://github.com/nsheaps/git-wt/archive/refs/tags/${{ steps.release.outputs.tag }}.tar.gz'
             sha256 '${{ steps.release.outputs.sha256 }}'
             license 'MIT'
 
@@ -148,11 +153,7 @@ jobs:
             depends_on 'gum'
 
             def install
-              if build.head?
-                bin.install 'bin/git-wt'
-              else
-                bin.install 'git-wt'
-              end
+              bin.install 'bin/git-wt'
             end
 
             test do


### PR DESCRIPTION
## Summary
- Embed version in script before release-it commits → tagged commit has version
- Archive tarball (from tag) has embedded version
- After release, reset to `__VERSION__` → main stays clean
- Formula uses archive tarball URL

## Flow
1. Get next version (e.g., 0.4.8)
2. `sed` embeds `v0.4.8` in `bin/git-wt`
3. `release-it` commits changelog + embedded version, creates tag
4. `gh release create` uploads versioned script
5. `sed` resets to `__VERSION__`, commits with `[skip ci]`
6. Result: tag has version, main has placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)